### PR TITLE
override docker executor helper image to resolve an issue w gitlab tl…

### DIFF
--- a/gitlab-runner/userdata.tmpl
+++ b/gitlab-runner/userdata.tmpl
@@ -64,7 +64,11 @@ if [ ! -z $HTTP_PROXY ]; then
 EOF
 
 fi
+cat >> /etc/gitlab-runner/config.template.toml <<EOF
 
+  [runners.docker]
+    helper_image = "gitlab/gitlab-runner-helper:x86_64-v13.7.0"
+EOF
 
 
 ##### register the shell runner


### PR DESCRIPTION
#### Description
The gitlab runner docker executor is not able to clone repo in pipeline jobs. this is the first step in any pipeline.
Specifically, the docker executor helper image has stopped copying /etc/gitlab-runner/certs to the executor container.

This change overrides the docker executor helper image to known working version so that jobs using docker executor work.